### PR TITLE
Fix gridplot example with pie charts

### DIFF
--- a/sphinx/source/docs/user_guide/bokehjs.rst
+++ b/sphinx/source/docs/user_guide/bokehjs.rst
@@ -255,7 +255,7 @@ function, with the plot it generates shown below:
         slice_labels: "percentages"
     });
 
-    plt.show(plt.gridplot([p1, p2, p3, p4]));
+    plt.show(plt.gridplot([[p1, p2, p3, p4]]));
 
 .. image:: /_images/bokehjs_pie_charts.png
     :width: 100%


### PR DESCRIPTION
Call to gridplot needs a nested list as argument. Should fix #8428.
